### PR TITLE
Decorate all pure methods as such with the [Pure] attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,3 +33,5 @@ dotnet_diagnostic.S3376.severity = none
 dotnet_diagnostic.S4136.severity = none
 # CS0649: Field is never assigned to, and will always have its default value
 dotnet_diagnostic.CS0649.severity = none
+# CS1806: Return values should not be ignored
+dotnet_diagnostic.CA1806.severity = warning

--- a/src/Qowaiv.DomainModel/AggregateRoot.cs
+++ b/src/Qowaiv.DomainModel/AggregateRoot.cs
@@ -1,4 +1,6 @@
-﻿namespace Qowaiv.DomainModel
+﻿using System.Diagnostics.Contracts;
+
+namespace Qowaiv.DomainModel
 {
     /// <summary>Factory method for creating <see cref="AggregateRoot{TAggregate, TId}"/> from stored events.</summary>
     public static class AggregateRoot
@@ -13,6 +15,7 @@
         /// <param name="buffer">
         /// The buffer to replay.
         /// </param>
+        [Pure]
         public static TAggregate FromStorage<TAggregate, TId>(EventBuffer<TId> buffer)
             where TAggregate : AggregateRoot<TAggregate, TId>, new()
         {

--- a/src/Qowaiv.DomainModel/AggregateRoot_TAggregate.cs
+++ b/src/Qowaiv.DomainModel/AggregateRoot_TAggregate.cs
@@ -4,6 +4,7 @@ using Qowaiv.Validation.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Qowaiv.DomainModel
 {
@@ -56,13 +57,16 @@ namespace Qowaiv.DomainModel
         protected abstract TAggregate Clone();
 
         /// <summary>Applies a single event.</summary>
+        [Pure]
         protected Result<TAggregate> ApplyEvent(object @event) => ApplyEvents(@event);
 
         /// <summary>Applies the events.</summary>
+        [Pure]
         protected Result<TAggregate> ApplyEvents(params object[] events)
             => Apply(events);
 
         /// <summary>Applies the events.</summary>
+        [Pure]
         protected Result<TAggregate> Apply(IEnumerable<object> events)
         {
             var updated = Clone();

--- a/src/Qowaiv.DomainModel/AggregateRoot_TAggregate_TId.cs
+++ b/src/Qowaiv.DomainModel/AggregateRoot_TAggregate_TId.cs
@@ -1,5 +1,6 @@
 ﻿using Qowaiv.Validation.Abstractions;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Qowaiv.DomainModel
@@ -38,6 +39,7 @@ namespace Qowaiv.DomainModel
             => Buffer = Buffer.Add(events);
 
         /// <inheritdoc/>
+        [Pure]
         protected override TAggregate Clone()
         {
             var cloned = new TAggregate();

--- a/src/Qowaiv.DomainModel/Collections/Collection.cs
+++ b/src/Qowaiv.DomainModel/Collections/Collection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Qowaiv.DomainModel.Collections
@@ -20,6 +21,7 @@ namespace Qowaiv.DomainModel.Collections
             private IEnumerable Items { get; }
 
             /// <inheritdoc />
+            [Pure]
             internal override IEnumerable<object> Enumerate()
                 => base.Enumerate().Append(Items);
         }

--- a/src/Qowaiv.DomainModel/Collections/Collection.cs
+++ b/src/Qowaiv.DomainModel/Collections/Collection.cs
@@ -20,7 +20,7 @@ namespace Qowaiv.DomainModel.Collections
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private IEnumerable Items { get; }
 
-            /// <inheritdoc />
+            /// <inheritdoc/>
             [Pure]
             internal override IEnumerable<object> Enumerate()
                 => base.Enumerate().Append(Items);

--- a/src/Qowaiv.DomainModel/Collections/If.cs
+++ b/src/Qowaiv.DomainModel/Collections/If.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Qowaiv.DomainModel.Collections
 {
@@ -34,6 +35,7 @@ namespace Qowaiv.DomainModel.Collections
         /// <remarks>
         /// Null, and null items are ignored.
         /// </remarks>
+        [Pure]
         public Then Then<TEvent>(Func<TEvent> item) where TEvent : class
         => State switch
         {

--- a/src/Qowaiv.DomainModel/Collections/ImmutableCollection.cs
+++ b/src/Qowaiv.DomainModel/Collections/ImmutableCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Qowaiv.DomainModel.Collections
@@ -28,6 +29,7 @@ namespace Qowaiv.DomainModel.Collections
         /// <remarks>
         /// Null, and null items are ignored.
         /// </remarks>
+        [Pure]
         public ImmutableCollection Add(params object[] items) => Add<object[]>(items);
 
         /// <summary>Creates a new <see cref="ImmutableCollection"/> with the added item(s).</summary>
@@ -40,6 +42,7 @@ namespace Qowaiv.DomainModel.Collections
         /// <remarks>
         /// Null, and null items are ignored.
         /// </remarks>
+        [Pure]
         public ImmutableCollection Add<TItem>(TItem item) where TItem : class
         => item switch
         {
@@ -50,19 +53,24 @@ namespace Qowaiv.DomainModel.Collections
         };
 
         /// <summary>Starts a conditional addition.</summary>
+        [Pure]
         public If If(bool? condition) => If(condition == true);
 
         /// <summary>Starts a conditional addition.</summary>
+        [Pure]
         public If If(bool condition) => new(condition, this);
 
         /// <inheritdoc />
+        [Pure]
         public IEnumerator<object> GetEnumerator()
             => Enumerate().GetEnumerator();
 
         /// <inheritdoc />
+        [Pure]
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>Enumerates through all events.</summary>
+        [Pure]
         internal virtual IEnumerable<object> Enumerate() => Enumerable.Empty<object>();
     }
 }

--- a/src/Qowaiv.DomainModel/Collections/ImmutableCollection.cs
+++ b/src/Qowaiv.DomainModel/Collections/ImmutableCollection.cs
@@ -60,12 +60,12 @@ namespace Qowaiv.DomainModel.Collections
         [Pure]
         public If If(bool condition) => new(condition, this);
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         [Pure]
         public IEnumerator<object> GetEnumerator()
             => Enumerate().GetEnumerator();
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         [Pure]
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Qowaiv.DomainModel/Collections/NotEmpty.cs
+++ b/src/Qowaiv.DomainModel/Collections/NotEmpty.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Qowaiv.DomainModel.Collections
 {
@@ -17,6 +18,7 @@ namespace Qowaiv.DomainModel.Collections
             private ImmutableCollection Predecessor { get; }
 
             /// <inheritdoc />
+            [Pure]
             internal override IEnumerable<object> Enumerate()
                 => Predecessor.Enumerate();
         }

--- a/src/Qowaiv.DomainModel/Collections/NotEmpty.cs
+++ b/src/Qowaiv.DomainModel/Collections/NotEmpty.cs
@@ -17,7 +17,7 @@ namespace Qowaiv.DomainModel.Collections
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private ImmutableCollection Predecessor { get; }
 
-            /// <inheritdoc />
+            /// <inheritdoc/>
             [Pure]
             internal override IEnumerable<object> Enumerate()
                 => Predecessor.Enumerate();

--- a/src/Qowaiv.DomainModel/Collections/Single.cs
+++ b/src/Qowaiv.DomainModel/Collections/Single.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Qowaiv.DomainModel.Collections
@@ -19,6 +20,7 @@ namespace Qowaiv.DomainModel.Collections
             private object Item { get; }
 
             /// <inheritdoc />
+            [Pure]
             internal override IEnumerable<object> Enumerate()
                 => base.Enumerate().Append(Item);
         }

--- a/src/Qowaiv.DomainModel/Collections/Single.cs
+++ b/src/Qowaiv.DomainModel/Collections/Single.cs
@@ -19,7 +19,7 @@ namespace Qowaiv.DomainModel.Collections
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private object Item { get; }
 
-            /// <inheritdoc />
+            /// <inheritdoc/>
             [Pure]
             internal override IEnumerable<object> Enumerate()
                 => base.Enumerate().Append(Item);

--- a/src/Qowaiv.DomainModel/Collections/Then.cs
+++ b/src/Qowaiv.DomainModel/Collections/Then.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Qowaiv.DomainModel.Collections
 {
@@ -23,6 +24,7 @@ namespace Qowaiv.DomainModel.Collections
         private bool Done { get; }
 
         /// <summary>Adds else-if condition.</summary>
+        [Pure]
         public If ElseIf(bool condition)
             => Done
             ? new If(IfState.Done, Predecessor)
@@ -39,12 +41,14 @@ namespace Qowaiv.DomainModel.Collections
         /// <remarks>
         /// Null, and null items are ignored.
         /// </remarks>
+        [Pure]
         public ImmutableCollection Else<TElseItem>(Func<TElseItem> item) where TElseItem : class
             => Done || item is null
             ? Predecessor
             : Predecessor.Add(item());
 
         /// <inheritdoc />
+        [Pure]
         internal override IEnumerable<object> Enumerate()
             => Predecessor.Enumerate();
     }

--- a/src/Qowaiv.DomainModel/Collections/Then.cs
+++ b/src/Qowaiv.DomainModel/Collections/Then.cs
@@ -47,7 +47,7 @@ namespace Qowaiv.DomainModel.Collections
             ? Predecessor
             : Predecessor.Add(item());
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         [Pure]
         internal override IEnumerable<object> Enumerate()
             => Predecessor.Enumerate();

--- a/src/Qowaiv.DomainModel/EventBuffer.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer.cs
@@ -1,5 +1,6 @@
 ﻿using Qowaiv.DomainModel.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Qowaiv.DomainModel
@@ -26,6 +27,7 @@ namespace Qowaiv.DomainModel
         /// <param name="aggregateId">
         /// The identifier of the aggregate root.
         /// </param>
+        [Pure]
         public static EventBuffer<TId> Empty<TId>(TId aggregateId) => Empty(aggregateId, 0);
 
         /// <summary>Gets an empty <see cref="EventBuffer{TId}"/>.</summary>
@@ -38,6 +40,7 @@ namespace Qowaiv.DomainModel
         /// <param name="version">
         /// The initial version (offset).
         /// </param>
+        [Pure]
         public static EventBuffer<TId> Empty<TId>(TId aggregateId, int version)
             => new(aggregateId, offset: version, committed: version, ImmutableCollection.Empty);
 
@@ -60,13 +63,12 @@ namespace Qowaiv.DomainModel
         /// <returns>
         /// An event buffer with contains only committed events.
         /// </returns>
+        [Pure]
         public static EventBuffer<TId> FromStorage<TId, TStoredEvent>(
             TId aggregateId,
             IEnumerable<TStoredEvent> storedEvents,
             ConvertFromStoredEvent<TStoredEvent> convert)
-        {
-            return FromStorage(aggregateId, 0, storedEvents, convert);
-        }
+            => FromStorage(aggregateId, 0, storedEvents, convert);
 
         /// <summary>Creates an event buffer from some storage.</summary>
         /// <typeparam name="TId">
@@ -90,6 +92,7 @@ namespace Qowaiv.DomainModel
         /// <returns>
         /// An event buffer with contains only committed events.
         /// </returns>
+        [Pure]
         public static EventBuffer<TId> FromStorage<TId, TStoredEvent>(
             TId aggregateId,
             int initialVersion,

--- a/src/Qowaiv.DomainModel/EventBuffer_TId.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer_TId.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Qowaiv.DomainModel
@@ -95,6 +96,7 @@ namespace Qowaiv.DomainModel
         /// <remarks>
         /// Null, and null items are ignored.
         /// </remarks>
+        [Pure]
         public EventBuffer<TId> Add(object @event)
             => new(AggregateId, offset, CommittedVersion, buffer.Add<object>(@event));
 
@@ -130,6 +132,7 @@ namespace Qowaiv.DomainModel
         /// <returns>
         /// The uncommitted events as <typeparamref name="TStoredEvent"/>.
         /// </returns>
+        [Pure]
         public IEnumerable<TStoredEvent> SelectUncommitted<TStoredEvent>(ConvertToStoredEvent<TId, TStoredEvent> convert)
         {
             Guard.NotNull(convert, nameof(convert));
@@ -137,9 +140,11 @@ namespace Qowaiv.DomainModel
         }
 
         /// <inheritdoc/>
+        [Pure]
         public IEnumerator<object> GetEnumerator() => buffer.GetEnumerator();
 
         /// <inheritdoc/>
+        [Pure]
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>Returns a <see cref="string"/> that represents the event buffer for debug purposes.</summary>

--- a/src/Qowaiv.DomainModel/EventTypeNotSupported.cs
+++ b/src/Qowaiv.DomainModel/EventTypeNotSupported.cs
@@ -49,7 +49,7 @@ namespace Qowaiv.DomainModel
         /// <summary>The aggregate for which the event type is not supported.</summary>
         public Type AggregateType { get; }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(Guard.NotNull(info, nameof(info)), context);


### PR DESCRIPTION
Most contract attributes are more or less obsolete ([as the project failed](https://www.infoq.com/news/2019/01/pure-attribute-net-core/)), but an exception is the [[Pure](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.pureattribute)] attribute.

To express the intend of the library, all [pure functions](https://en.wikipedia.org/wiki/Pure_function) are decorated as such. Also is helps rule [CA1806](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1806).