### PR TITLE
Introduction of CommandProcessor (base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,19 +199,18 @@ var updated = buffer.MarkAllAsCommitted();
 
 ## Command Processor
 An approach often used when applying event sourcing is the [(command pattern)https://en.wikipedia.org/wiki/Command_pattern];
-every change on the domain(s), is described by a command, that is handled by 
+every change on the domain(s) is triggerd by a command, which is handled by 
 a single command handler.
 
-As it should be irrelevant to the sender of the command, which handler handles
+As it should be irrelevant to the sender of the command which handler handles
 the command, a command processor can be useful to do just that: ensure that
 the registered handler handles the command at hand.
 
 The (abstract) `Qowaiv.DomainModel.Commands.CommandProcessor<TReturnType>`
-allows to call registered command handlers registered for a specific
-command (type). To reduce the usage of reflection, the actual call is a
-(one-time) compiled expression, stored in a dictionary. It can deal with any
-(except `void`, including both sync and async) return type, any (generic)
-command handler interface  of preference.
+orchestrates command handlers to command (types). To reduce the usage of reflection,
+the actual call is a (one-time) compiled expression, stored in a dictionary. It
+can deal with any (except `void`, including both sync and async) return type,
+and any (generic) command handler interface of preference.
 
 A typical implementation, using Microsoft's `System.IServiceProvider`,
 looks like this:

--- a/example/ConquerClub.Domain/Game.Actions.cs
+++ b/example/ConquerClub.Domain/Game.Actions.cs
@@ -1,7 +1,6 @@
 ﻿using ConquerClub.Domain.Commands;
 using ConquerClub.Domain.Events;
 using Qowaiv.DomainModel;
-using Qowaiv.Identifiers;
 using Qowaiv.Validation.Abstractions;
 using System;
 using System.Collections.Generic;

--- a/src/Qowaiv.DomainModel/Commands/CommandProcessor.cs
+++ b/src/Qowaiv.DomainModel/Commands/CommandProcessor.cs
@@ -6,8 +6,8 @@ using System.Reflection;
 
 namespace Qowaiv.DomainModel.Commands
 {
-    /// <summary>Command processor that resolves the registered command hander
-    /// base on type of the command.
+    /// <summary>Command processor that resolves the registered command handler
+    /// base on the type of the command.
     /// </summary>
     /// <typeparam name="TReturnType">
     /// The return type of the command handler methods

--- a/src/Qowaiv.DomainModel/Commands/CommandProcessor.cs
+++ b/src/Qowaiv.DomainModel/Commands/CommandProcessor.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Qowaiv.DomainModel.Commands
+{
+    /// <summary>Command processor that resolves the registered command hander
+    /// base on type of the command.
+    /// </summary>
+    /// <typeparam name="TReturnType">
+    /// The return type of the command handler methods
+    /// </typeparam>
+    /// <remarks>
+    /// It compiles (one time per command type) the expression to handle the
+    /// command on the command handler.
+    /// </remarks>
+    public abstract class CommandProcessor<TReturnType>
+    {
+        /// <summary>The generic type definition of the command handlers to support.</summary>
+        /// <remarks>
+        /// Something like <code>typeof(CommandHandler&lt;&gt;)</code>.
+        /// </remarks>
+        protected abstract Type GenericHandlerType { get; }
+
+        /// <summary>The name of the method defined on the generic interface.</summary>
+        /// <remarks>
+        /// Something like "Handle", or "HandleAsync".
+        /// </remarks>
+        protected abstract string HandlerMethod { get; }
+        
+        /// <summary>Gets the command handler to send the command to.</summary>
+        /// <param name="handlerType">
+        /// The resolved command handler type to get the instance of.
+        /// </param>
+        /// <remarks>
+        /// This is the method that could/should hook on to your DI of choice.
+        /// </remarks>
+        protected abstract object GetHandler(Type handlerType);
+
+        /// <summary>Sends the command to the registered command handler and
+        /// communicates its response.
+        /// </summary>
+        /// <param name="command">
+        /// The command that should be handled by some command handler.
+        /// </param>
+        /// <returns>
+        /// The response of the registered command handler.
+        /// </returns>
+        public TReturnType Send(object command)
+        {
+            var commandType = Guard.NotNull(command, nameof(command)).GetType();
+            var handlerType = HandlerTypeFor(commandType);
+            var handler = GetHandler(handlerType) ?? throw new UnresolvedCommandHandler(handlerType);
+            return Handle(handlerType, commandType)(handler, command);
+        }
+
+        /// <summary>Gets function to invoke.</summary>
+        private Func<object, object, TReturnType> Handle(Type handler, Type command)
+        {
+            if (!handlers.TryGetValue(command, out var handle))
+            {
+                handle = GetExpression(GetMethod(handler, command)).Compile();
+                handlers[command] = handle;
+            }
+            return handle;
+        }
+
+        /// <summary>Gets the generic interface for the specific command handler.</summary>
+        /// <param name="commandType">
+        /// The type of the command to process.
+        /// </param>
+        private Type HandlerTypeFor(Type commandType) => GenericHandlerType.MakeGenericType(commandType);
+
+        /// <summary>Gets the <see cref="MethodInfo"/> for the handler method to call.</summary>
+        private MethodInfo GetMethod(Type handlerType, Type commandType)
+            => handlerType.GetMethods()
+                .Single(m => m.Name == HandlerMethod
+                    && m.GetParameters().Length == 1
+                    && m.GetParameters()[0].ParameterType == commandType);
+
+        /// <summary>Gets an expression that calls the Handle method.</summary>
+        /// <remarks>
+        /// (handler, cmd) => ((HandlerType)handler).{HandlerMethod}((CommandType)cmd);
+        /// </remarks>
+        private static Expression<Func<object, object, TReturnType>> GetExpression(MethodInfo method)
+        {
+            var handler = Expression.Parameter(typeof(object), "handler");
+            var cmd = Expression.Parameter(typeof(object), "cmd");
+            var typedCommand = Expression.Convert(cmd, method.GetParameters()[0].ParameterType);
+            var typedHandler = Expression.Convert(handler, method.DeclaringType);
+            var body = Expression.Call(typedHandler, method, typedCommand);
+            return Expression.Lambda<Func<object, object, TReturnType>>(body, handler, cmd);
+        }
+
+        private readonly Dictionary<Type, Func<object, object, TReturnType>> handlers = new();
+    }
+}

--- a/src/Qowaiv.DomainModel/Commands/UnresolvedCommandHandler.cs
+++ b/src/Qowaiv.DomainModel/Commands/UnresolvedCommandHandler.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.Serialization;
+
+namespace Qowaiv.DomainModel.Commands
+{
+    /// <summary>The exception that is thrown when a command handler type could not be resolved.</summary>
+    [Serializable]
+    public class UnresolvedCommandHandler : InvalidOperationException
+    {
+        /// <summary>The command hander type that could not be resolved.</summary>
+        public Type CommandHandlerType { get; }
+
+        /// <summary>Initializes a new instance of the <see cref="UnresolvedCommandHandler"/> class.</summary>
+        public UnresolvedCommandHandler(Type commandHandlerType)
+            : this(string.Format(CultureInfo.CurrentCulture, QowaivDomainModelMessages.UnresolvedCommandHandler_Type, commandHandlerType))
+            => CommandHandlerType = commandHandlerType;
+
+        /// <summary>Initializes a new instance of the <see cref="UnresolvedCommandHandler"/> class.</summary>
+        [ExcludeFromCodeCoverage/* Required Exception constructor for inheritance. */]
+        public UnresolvedCommandHandler() : this(QowaivDomainModelMessages.UnresolvedCommandHandler) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnresolvedCommandHandler"/> class.</summary>
+        [ExcludeFromCodeCoverage/* Required Exception constructor for inheritance. */]
+        public UnresolvedCommandHandler(string message) : base(message) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnresolvedCommandHandler"/> class.</summary>
+        [ExcludeFromCodeCoverage/* Required Exception constructor for inheritance. */]
+        public UnresolvedCommandHandler(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        /// <summary>Initializes a new instance of the <see cref="UnresolvedCommandHandler"/> class.</summary>
+        protected UnresolvedCommandHandler(SerializationInfo info, StreamingContext context) 
+            : base(info, context)
+        {
+            Guard.NotNull(info, nameof(info));
+            CommandHandlerType = Type.GetType(info.GetString(nameof(CommandHandlerType)));
+        }
+
+        /// <inheritdoc />
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(Guard.NotNull(info, nameof(info)), context);
+            info.AddValue(nameof(CommandHandlerType), CommandHandlerType?.AssemblyQualifiedName);
+        }
+    }
+}

--- a/src/Qowaiv.DomainModel/Commands/UnresolvedCommandHandler.cs
+++ b/src/Qowaiv.DomainModel/Commands/UnresolvedCommandHandler.cs
@@ -9,7 +9,7 @@ namespace Qowaiv.DomainModel.Commands
     [Serializable]
     public class UnresolvedCommandHandler : InvalidOperationException
     {
-        /// <summary>The command hander type that could not be resolved.</summary>
+        /// <summary>The command handler type that could not be resolved.</summary>
         public Type CommandHandlerType { get; }
 
         /// <summary>Initializes a new instance of the <see cref="UnresolvedCommandHandler"/> class.</summary>

--- a/src/Qowaiv.DomainModel/EventTypeNotSupported.cs
+++ b/src/Qowaiv.DomainModel/EventTypeNotSupported.cs
@@ -18,7 +18,7 @@ namespace Qowaiv.DomainModel
 
         private static string GetMessage(Type eventType, Type aggragateType) =>
             string.Format(
-                QowaivDomainModelMessages.EventTypeNotSupportedException,
+                QowaivDomainModelMessages.EventTypeNotSupported,
                 eventType?.ToString() ?? "{null}",
                 aggragateType ?? typeof(AggregateRoot<>));
 
@@ -53,8 +53,8 @@ namespace Qowaiv.DomainModel
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(Guard.NotNull(info, nameof(info)), context);
-            info.AddValue(nameof(EventType), EventType.AssemblyQualifiedName);
-            info.AddValue(nameof(AggregateType), AggregateType.AssemblyQualifiedName);
+            info.AddValue(nameof(EventType), EventType?.AssemblyQualifiedName);
+            info.AddValue(nameof(AggregateType), AggregateType?.AssemblyQualifiedName);
         }
     }
 }

--- a/src/Qowaiv.DomainModel/QowaivDomainModelMessages.Designer.cs
+++ b/src/Qowaiv.DomainModel/QowaivDomainModelMessages.Designer.cs
@@ -70,7 +70,7 @@ namespace Qowaiv.DomainModel {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The command hander could not be resolved..
+        ///   Looks up a localized string similar to The command handler could not be resolved..
         /// </summary>
         public static string UnresolvedCommandHandler {
             get {
@@ -79,7 +79,7 @@ namespace Qowaiv.DomainModel {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The command hander {0} could not be resolved..
+        ///   Looks up a localized string similar to The command handler {0} could not be resolved..
         /// </summary>
         public static string UnresolvedCommandHandler_Type {
             get {

--- a/src/Qowaiv.DomainModel/QowaivDomainModelMessages.Designer.cs
+++ b/src/Qowaiv.DomainModel/QowaivDomainModelMessages.Designer.cs
@@ -63,9 +63,27 @@ namespace Qowaiv.DomainModel {
         /// <summary>
         ///   Looks up a localized string similar to The event of the type {0} is not supported for {1}..
         /// </summary>
-        public static string EventTypeNotSupportedException {
+        public static string EventTypeNotSupported {
             get {
-                return ResourceManager.GetString("EventTypeNotSupportedException", resourceCulture);
+                return ResourceManager.GetString("EventTypeNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The command hander could not be resolved..
+        /// </summary>
+        public static string UnresolvedCommandHandler {
+            get {
+                return ResourceManager.GetString("UnresolvedCommandHandler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The command hander {0} could not be resolved..
+        /// </summary>
+        public static string UnresolvedCommandHandler_Type {
+            get {
+                return ResourceManager.GetString("UnresolvedCommandHandler_Type", resourceCulture);
             }
         }
     }

--- a/src/Qowaiv.DomainModel/QowaivDomainModelMessages.resx
+++ b/src/Qowaiv.DomainModel/QowaivDomainModelMessages.resx
@@ -16,9 +16,9 @@
     <value>The event of the type {0} is not supported for {1}.</value>
   </data>
   <data name="UnresolvedCommandHandler" xml:space="preserve">
-    <value>The command hander could not be resolved.</value>
+    <value>The command handler could not be resolved.</value>
   </data>
   <data name="UnresolvedCommandHandler_Type" xml:space="preserve">
-    <value>The command hander {0} could not be resolved.</value>
+    <value>The command handler {0} could not be resolved.</value>
   </data>
 </root>

--- a/src/Qowaiv.DomainModel/QowaivDomainModelMessages.resx
+++ b/src/Qowaiv.DomainModel/QowaivDomainModelMessages.resx
@@ -12,7 +12,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="EventTypeNotSupportedException" xml:space="preserve">
+  <data name="EventTypeNotSupported" xml:space="preserve">
     <value>The event of the type {0} is not supported for {1}.</value>
+  </data>
+  <data name="UnresolvedCommandHandler" xml:space="preserve">
+    <value>The command hander could not be resolved.</value>
+  </data>
+  <data name="UnresolvedCommandHandler_Type" xml:space="preserve">
+    <value>The command hander {0} could not be resolved.</value>
   </data>
 </root>

--- a/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
@@ -13,18 +13,15 @@ namespace Commands.CommandProcessor_specs
         public async Task a_command()
         {
             var processor = new NumberProcessor(new NumberHandler());
-            var response = await processor.Send(new One());
-            response.Value.Should().Be(1);
+            (await processor.Send(new One())).Value.Should().Be(1);
         }
 
         [Test]
         public async Task a_second_command_using_precompiled_func()
         {
             var processor = new NumberProcessor(new NumberHandler());
-            var first = await processor.Send(new Two());
-            var second = await processor.Send(new Two());
-            first.Value.Should().Be(2);
-            second.Value.Should().Be(2);
+            (await processor.Send(new Two())).Value.Should().Be(2);
+            (await processor.Send(new Two())).Value.Should().Be(2);
         }
     }
 
@@ -42,7 +39,7 @@ namespace Commands.CommandProcessor_specs
         {
             Action send = () => new NumberProcessor(null).Send(new One());
             send.Should().Throw<UnresolvedCommandHandler>()
-                .WithMessage("The command hander Commands.CommandProcessor_specs.CommandHandler`1[Commands.CommandProcessor_specs.One] could not be resolved.");
+                .WithMessage("The command handler Commands.CommandProcessor_specs.CommandHandler`1[Commands.CommandProcessor_specs.One] could not be resolved.");
         }
     }
 
@@ -59,8 +56,11 @@ namespace Commands.CommandProcessor_specs
     {
         Task<Result<int>> Handle(TCommand command);
     }
+
     record One();
+
     record Two();
+
     class NumberHandler :
         CommandHandler<One>,
         CommandHandler<Two>

--- a/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
@@ -1,0 +1,71 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Qowaiv.DomainModel.Commands;
+using Qowaiv.Validation.Abstractions;
+using System;
+using System.Threading.Tasks;
+
+namespace Commands.CommandProcessor_specs
+{
+    public class Sends
+    {
+        [Test]
+        public async Task a_command()
+        {
+            var processor = new NumberProcessor(new NumberHandler());
+            var response = await processor.Send(new One());
+            Assert.That(response.Value, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task a_second_command_using_precompiled_func()
+        {
+            var processor = new NumberProcessor(new NumberHandler());
+            var first = await processor.Send(new Two());
+            var second = await processor.Send(new Two());
+            Assert.That(first.Value, Is.EqualTo(2));
+            Assert.That(second.Value, Is.EqualTo(2));
+        }
+    }
+
+    public class Throws
+    {
+        [Test]
+        public void for_null_commands()
+        {
+            Action send = () => new NumberProcessor(new NumberHandler()).Send(null);
+            send.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void for_not_registered_commands()
+        {
+            Action send = () => new NumberProcessor(null).Send(new One());
+            send.Should().Throw<UnresolvedCommandHandler>()
+                .WithMessage("The command hander Commands.CommandProcessor_specs.CommandHandler`1[Commands.CommandProcessor_specs.One] could not be resolved.");
+        }
+    }
+
+    class NumberProcessor : CommandProcessor<Task<Result<int>>>
+    {
+        private readonly object handler;
+        public NumberProcessor(object handler) => this.handler = handler;
+        protected override Type GenericHandlerType => typeof(CommandHandler<>);
+        protected override string HandlerMethod => nameof(CommandHandler<object>.Handle);
+        protected override object GetHandler(Type handlerType) => handler;
+    }
+
+    interface CommandHandler<TCommand>
+    {
+        Task<Result<int>> Handle(TCommand command);
+    }
+    record One();
+    record Two();
+    class NumberHandler :
+        CommandHandler<One>,
+        CommandHandler<Two>
+    {
+        public Task<Result<int>> Handle(One command) => Result.For(1).AsTask();
+        public Task<Result<int>> Handle(Two command) => Result.For(2).AsTask();
+    }
+}

--- a/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
@@ -14,7 +14,7 @@ namespace Commands.CommandProcessor_specs
         {
             var processor = new NumberProcessor(new NumberHandler());
             var response = await processor.Send(new One());
-            Assert.That(response.Value, Is.EqualTo(1));
+            response.Value.Should().Be(1);
         }
 
         [Test]
@@ -23,8 +23,8 @@ namespace Commands.CommandProcessor_specs
             var processor = new NumberProcessor(new NumberHandler());
             var first = await processor.Send(new Two());
             var second = await processor.Send(new Two());
-            Assert.That(first.Value, Is.EqualTo(2));
-            Assert.That(second.Value, Is.EqualTo(2));
+            first.Value.Should().Be(2);
+            second.Value.Should().Be(2);
         }
     }
 

--- a/test/Qowaiv.DomainModel.UnitTests/Qowaiv.DomainModel.UnitTests.csproj
+++ b/test/Qowaiv.DomainModel.UnitTests/Qowaiv.DomainModel.UnitTests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />


### PR DESCRIPTION
This command processor is DI unaware (no technical lock-in). It allows to call registered command handlers registered for a specific command (type). To reduce the usage of reflection, the actual call is a (one-time) compiled expression, stored in a dictionary. It can deal with any (except `void`, including both sync and async) return type, any (generic) command handler interface  of preference.

A typical implementation, using `System.IServiceProvider`, looks like this:

``` C#
class CommandProcessor : CommandProcessor<Task<Result>>
{
	CommandProcessor(IServiceProvider provider) => Provider = provider;
	protected override Type GenericHandlerType => typeof(CommandHandler<>);
	protected override string HandlerMethod => nameof(CommandHandler<object>.Handle);
	protected override object GetHandler(Type handlerType) => Provider.GetService(handlerType);
	private readonly IServiceProvider Provider;
}
```