### PR TITLE
EventBuffer implement ICollection<object>

### DIFF
--- a/src/Qowaiv.DomainModel/EventBuffer_TId.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer_TId.cs
@@ -51,7 +51,11 @@ public readonly struct EventBuffer<TId> : IReadOnlyCollection<object>, ICollecti
     /// <summary>Gets the committed version of the event buffer.</summary>
     public int CommittedVersion { get; }
 
-    /// <inheritdoc cref="IReadOnlyCollection{T}.Count" />
+    /// <summary>Gets the number of events in the event buffer.</summary>
+    /// <remarks>
+    /// This number is not the version. It can be lower when the event buffer has
+    /// been created using an initial version.
+    /// </remarks>
     public int Count => Buffer.Count;
 
     /// <summary>Get all committed events in the event buffer.</summary>

--- a/src/Qowaiv.DomainModel/EventBuffer_TId.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer_TId.cs
@@ -28,7 +28,7 @@ public delegate TStoredEvent ConvertToStoredEvent<in TId, out TStoredEvent>(TId 
 /// </typeparam>
 [DebuggerDisplay("{DebuggerDisplay}")]
 [DebuggerTypeProxy(typeof(CollectionDebugView))]
-public readonly struct EventBuffer<TId> : IEnumerable<object>
+public readonly struct EventBuffer<TId> : ICollection<object>
 {
     private readonly AppendOnlyCollection Buffer;
     private readonly int Offset;
@@ -98,6 +98,13 @@ public readonly struct EventBuffer<TId> : IEnumerable<object>
         return Uncommitted.Select((@event, index) => convert(self.AggregateId, self.CommittedVersion + index + 1, @event));
     }
 
+    /// <inheritdoc />
+    public void CopyTo(object[] array, int arrayIndex) => Buffer.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc />
+    [Pure]
+    bool ICollection<object>.Contains(object item) => Buffer.Contains(item);
+
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()" />
     [Pure]
     public Enumerator GetEnumerator() => Buffer.GetEnumerator();
@@ -116,4 +123,20 @@ public readonly struct EventBuffer<TId> : IEnumerable<object>
         => Version == CommittedVersion
         ? $"Version: {Version}, Aggregate: {AggregateId}"
         : $"Version: {Version} (Committed: {CommittedVersion}), Aggregate: {AggregateId}";
+
+    /// <inheritdoc />
+    int ICollection<object>.Count => Buffer.Count;
+
+    /// <inheritdoc />
+    bool ICollection<object>.IsReadOnly => true;
+
+    /// <inheritdoc />
+    void ICollection<object>.Add(object item) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    void ICollection<object>.Clear() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    [Pure]
+    bool ICollection<object>.Remove(object item) => throw new NotSupportedException();
 }

--- a/src/Qowaiv.DomainModel/EventBuffer_TId.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer_TId.cs
@@ -103,7 +103,7 @@ public readonly struct EventBuffer<TId> : ICollection<object>
 
     /// <inheritdoc />
     [Pure]
-    bool ICollection<object>.Contains(object item) => Buffer.Contains(item);
+    public bool Contains(object item) => Buffer.Contains(item);
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()" />
     [Pure]

--- a/src/Qowaiv.DomainModel/EventBuffer_TId.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer_TId.cs
@@ -28,7 +28,7 @@ public delegate TStoredEvent ConvertToStoredEvent<in TId, out TStoredEvent>(TId 
 /// </typeparam>
 [DebuggerDisplay("{DebuggerDisplay}")]
 [DebuggerTypeProxy(typeof(CollectionDebugView))]
-public readonly struct EventBuffer<TId> : ICollection<object>
+public readonly struct EventBuffer<TId> : IReadOnlyCollection<object>, ICollection<object>
 {
     private readonly AppendOnlyCollection Buffer;
     private readonly int Offset;
@@ -50,6 +50,9 @@ public readonly struct EventBuffer<TId> : ICollection<object>
 
     /// <summary>Gets the committed version of the event buffer.</summary>
     public int CommittedVersion { get; }
+
+    /// <inheritdoc cref="IReadOnlyCollection{T}.Count" />
+    public int Count => Buffer.Count;
 
     /// <summary>Get all committed events in the event buffer.</summary>
     public IEnumerable<object> Committed => Buffer.Take(CommittedVersion - Offset);
@@ -123,9 +126,6 @@ public readonly struct EventBuffer<TId> : ICollection<object>
         => Version == CommittedVersion
         ? $"Version: {Version}, Aggregate: {AggregateId}"
         : $"Version: {Version} (Committed: {CommittedVersion}), Aggregate: {AggregateId}";
-
-    /// <inheritdoc />
-    int ICollection<object>.Count => Buffer.Count;
 
     /// <inheritdoc />
     bool ICollection<object>.IsReadOnly => true;

--- a/src/Qowaiv.DomainModel/Internal/AppendOnlyCollection.cs
+++ b/src/Qowaiv.DomainModel/Internal/AppendOnlyCollection.cs
@@ -48,6 +48,15 @@ internal readonly struct AppendOnlyCollection : IReadOnlyCollection<object>
         }
     }
 
+    /// <inheritdoc cref="ICollection.CopyTo(Array, int)" />
+    public void CopyTo(object[] array, int arrayIndex)
+    {
+        if (Count > 0)
+        {
+            Array.Copy(Buffer, 0, array, arrayIndex, Count);
+        }
+    }
+
     /// <summary>Returns a specified range of contiguous elements from the collection.</summary>
     [Pure]
     public Enumerator Take(int count) => new(Buffer, Math.Min(count, Count));

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -9,7 +9,8 @@
     <PackageReleaseNotes>
 NextRelease
 - Re-implemented ImmutableCollection. #34 (breaking)
-- EventStream as struct. #34 (breaking)
+- EventBuffer as struct. #34 (breaking)
+- EventBuffer implements ICollection&lt;object&gt;. #36
 - EventDispatcher without dynamics. #34 (breaking)
 - Enable annotations. #31
 - Publish .NET 7.0. #29

--- a/test/Qowaiv.DomainModel.UnitTests/Event_buffer_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Event_buffer_specs.cs
@@ -143,6 +143,13 @@ public class Debugger_display
 public class Implements_ICollection
 {
     [Test]
+    public void Count_is_equal_to_buffer_count()
+    {
+        var collection = EventBuffer.Empty(17).Add(new[] { 1, 2, 3, 4 });
+        collection.Count.Should().Be(4);
+    }
+
+    [Test]
     public void returns_true_for_contained_events()
     {
         var @event = new EmptyEvent();
@@ -207,13 +214,6 @@ public class Implements_ICollection
         {
             ICollection<object> collection = EventBuffer.Empty(17);
             collection.IsReadOnly.Should().BeTrue();
-        }
-
-        [Test]
-        public void Count()
-        {
-            ICollection<object> collection = EventBuffer.Empty(17).Add(new[] { 1, 2, 3, 4 });
-            collection.Count.Should().Be(4);
         }
 
         public class Does_not_support

--- a/test/Qowaiv.DomainModel.UnitTests/Models/_events.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Models/_events.cs
@@ -1,0 +1,6 @@
+﻿namespace Qowaiv.DomainModel.UnitTests.Models;
+
+[EmptyTestClass]
+internal record EmptyEvent();
+
+internal record StoredEvent(object Id, int Version, object Payload);


### PR DESCRIPTION
The main idea here, is that be implementing `ICollection<object>` (and `ICollection`) potentially, some .NET code will perform even better when dealing with an `EventBuffer<TId>`.

As an example we can look at `List<object>.AddRange()`, that will use `ICollection.CopyTo` to copy all items at once, instead of iterating them.