### PR TITLE
EventBuffer.Version nad AggregateVersion as long

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,6 +65,7 @@ dotnet_diagnostic.SA1307.severity = none # Fields should begin with upper-case c
 dotnet_diagnostic.SA1308.severity = none # Fields should begin with 'm_' prefix.
 dotnet_diagnostic.SA1309.severity = none # Fields should begin with underscore.
 dotnet_diagnostic.SA1310.severity = none # Fields should not contain underscores.
+dotnet_diagnostic.SA1302.severity = none # Interface names should start with an I.
 dotnet_diagnostic.SA1311.severity = none # Static read-only fields should begin with upper-case character.
 dotnet_diagnostic.SA1503.severity = none # Braces should not be omitted.
 dotnet_diagnostic.SA1513.severity = none # Closing brace should be followed by an empty line.

--- a/specs/Benchmarks/Collections/Creation.cs
+++ b/specs/Benchmarks/Collections/Creation.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace Benchmarks.Collections;
+﻿namespace Benchmarks.Collections;
 
 [MemoryDiagnoser]
 public class Creation

--- a/src/Qowaiv.DomainModel.TestTools/AggregateRootAssert.cs
+++ b/src/Qowaiv.DomainModel.TestTools/AggregateRootAssert.cs
@@ -100,7 +100,7 @@ public static class AggregateRootAssert
     }
 
     [Impure]
-    private static bool AppendEvents(this StringBuilder sb, int index, object exp, object act)
+    private static bool AppendEvents(this StringBuilder sb, long index, object exp, object act)
     {
         if (sb.AppendDifferentTypes(index, exp, act))
         {
@@ -116,7 +116,7 @@ public static class AggregateRootAssert
     }
 
     [Impure]
-    private static bool AppendDifferentTypes(this StringBuilder sb, int index, object exp, object act)
+    private static bool AppendDifferentTypes(this StringBuilder sb, long index, object exp, object act)
     {
         var actType = act.GetType();
         var expType = exp.GetType();
@@ -130,7 +130,7 @@ public static class AggregateRootAssert
     }
 
     [Impure]
-    private static bool AppendDifferentEvents(this StringBuilder sb, int index, object exp, object act)
+    private static bool AppendDifferentEvents(this StringBuilder sb, long index, object exp, object act)
     {
         var failure = false;
 
@@ -189,14 +189,14 @@ public static class AggregateRootAssert
     }
 
     [Impure]
-    private static bool AppendIdenticalEvents(this StringBuilder sb, int index, object @event)
+    private static bool AppendIdenticalEvents(this StringBuilder sb, long index, object @event)
     {
         sb.AppendLine($"[{index}] {@event.GetType().Name}");
         return false;
     }
 
     [Impure]
-    private static bool AppendExtraEvents(this StringBuilder sb, IEnumerable<object> events, int offset, int skip, string prefix)
+    private static bool AppendExtraEvents(this StringBuilder sb, IEnumerable<object> events, long offset, int skip, string prefix)
     {
         var index = offset + skip;
 
@@ -213,7 +213,7 @@ public static class AggregateRootAssert
     }
 
     [Impure]
-    private static bool AppendExpectedActual(this StringBuilder sb, int index, object expected, object actual)
+    private static bool AppendExpectedActual(this StringBuilder sb, long index, object expected, object actual)
     {
         var prefix = $"[{index}] ";
         var empty = new string(' ', prefix.Length);

--- a/src/Qowaiv.DomainModel/Aggregate_TAggregate_TId.cs
+++ b/src/Qowaiv.DomainModel/Aggregate_TAggregate_TId.cs
@@ -24,7 +24,7 @@ public class Aggregate<TAggregate, TId> : Aggregate<TAggregate>
     public TId Id => Buffer.AggregateId;
 
     /// <summary>Gets the version of aggregate.</summary>
-    public int Version => Buffer.Version;
+    public long Version => Buffer.Version;
 
     /// <summary>Gets the buffer with the recently added events.</summary>
     public EventBuffer<TId> Buffer { get; protected set; }

--- a/src/Qowaiv.DomainModel/EventBuffer_TId.cs
+++ b/src/Qowaiv.DomainModel/EventBuffer_TId.cs
@@ -62,14 +62,14 @@ public readonly struct EventBuffer<TId> : IReadOnlyCollection<object>, ICollecti
     public int Count => Buffer.Count;
 
     /// <summary>Get all committed events in the event buffer.</summary>
-    public IEnumerable<object> Committed => Buffer.Take(CommitedOffset());
+    public IEnumerable<object> Committed => Buffer.Take(CommittedOffset());
 
     /// <summary>Get all uncommitted events in the event buffer.</summary>
-    public IEnumerable<object> Uncommitted => Buffer.Skip(CommitedOffset());
+    public IEnumerable<object> Uncommitted => Buffer.Skip(CommittedOffset());
 
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int CommitedOffset() => checked((int)(CommittedVersion - Offset));
+    private int CommittedOffset() => checked((int)(CommittedVersion - Offset));
 
     /// <summary>Returns true if the event buffer contains at least one uncommitted event.</summary>
     public bool HasUncommitted => Version != CommittedVersion;

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -10,8 +10,9 @@
 NextRelease
 - Renamed AggregateRoot to Aggregate. #35 (breaking)
 - Re-implemented ImmutableCollection. #34 (breaking)
+- EventBuffer and Aggregate Version are of type long. #39 (breaking)
 - EventBuffer as struct. #34 (breaking)
-- EventBuffer implements ICollection&lt;object&gt;. #36
+- EventBuffer implements IReadOnlyCollection&lt;object&gt; and ICollection&lt;object&gt;. #36
 - EventDispatcher without dynamics. #34 (breaking)
 - Enable annotations. #31
 - Publish .NET 7.0. #29

--- a/src/Qowaiv.DomainModel/Qowaiv.Validation.Guarding/Musts.cs
+++ b/src/Qowaiv.DomainModel/Qowaiv.Validation.Guarding/Musts.cs
@@ -21,12 +21,12 @@ public static class DomainModelExtensions
     /// extension.
     /// </remarks>
     [Pure]
-    public static Result<TAggregate> HaveVersion<TAggregate>(this Must<TAggregate> must, int expected)
+    public static Result<TAggregate> HaveVersion<TAggregate>(this Must<TAggregate> must, long expected)
         where TAggregate : Aggregate<TAggregate>, new()
     {
         Guard.NotNull(must, nameof(must));
         Guard.NotNegative(expected, nameof(expected));
-        int actual = ((dynamic)must.Subject).Version;
+        long actual = ((dynamic)must.Subject).Version;
         return must.Be(actual == expected, ConcurrencyIssue.VersionMismatch(expected, actual));
     }
 }

--- a/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Commands/CommandProcessor_specs.cs
@@ -40,7 +40,7 @@ public class Throws_when
     [Test]
     public void hander_could_not_be_resolved()
     {
-        Action send = () => new InvalidReturnTypeProcessor(null).Send(new EmptyCommand());
+        Action send = () => new InvalidReturnTypeProcessor(null!).Send(new EmptyCommand());
         send.Should().Throw<UnresolvedCommandHandler>().WithMessage(
             "The command handler Commands.CommandProcessor_specs.SyncCommandHandler`1[Commands.CommandProcessor_specs.EmptyCommand] could not be resolved.");
     }

--- a/test/Qowaiv.DomainModel.UnitTests/Models/Events/StoredEvent.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Models/Events/StoredEvent.cs
@@ -1,3 +1,3 @@
 ﻿namespace Models.Events;
 
-public sealed record StoredEvent(object Id, int Version, object Payload);
+public sealed record StoredEvent(object Id, long Version, object Payload);

--- a/test/Qowaiv.DomainModel.UnitTests/Models/SimpleEventSourcedAggregate.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Models/SimpleEventSourcedAggregate.cs
@@ -1,6 +1,4 @@
-﻿using Models.Events;
-
-namespace Qowaiv.DomainModel.UnitTests.Models;
+﻿namespace Qowaiv.DomainModel.UnitTests.Models;
 
 public sealed class SimpleEventSourcedAggregate : Aggregate<SimpleEventSourcedAggregate, Guid>
 {

--- a/test/Qowaiv.DomainModel.UnitTests/Reflection/Expression_compiling_event_dispatcher_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Reflection/Expression_compiling_event_dispatcher_specs.cs
@@ -89,12 +89,6 @@ public class Not_supported_when_methods
             .Should().NotThrow();
     }
 
-
-    internal class WhenWithDummyEvent
-    {
-        internal void When(DummyEvent _) => throw new Detected();
-    }
-
     internal class WhenWithMultipleParameters
     {
         internal void When(DummyEvent @event, int other) => throw new NotSupportedException($"{@event} + {other}.");

--- a/test/Qowaiv.DomainModel.UnitTests/TestTools/QowaivAssemblyAssertions.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/TestTools/QowaivAssemblyAssertions.cs
@@ -1,30 +1,27 @@
 ﻿using FluentAssertions.Execution;
 using FluentAssertions.Reflection;
-using Qowaiv;
-using System;
 using System.Reflection;
 
-namespace FluentAssertions
+namespace FluentAssertions;
+
+/// <summary>Extensions on <see cref="AssemblyAssertions"/>.</summary>
+internal static class QowaivAssemblyAssertions
 {
-    /// <summary>Extensions on <see cref="AssemblyAssertions"/>.</summary>
-    public static class QowaivAssemblyAssertions
+    /// <summary>Asserts the <see cref="Assembly"/> to have a specific public key.</summary>
+    public static AndConstraint<AssemblyAssertions> HavePublicKey(this AssemblyAssertions assertions, string publicKey, string because = "", params object[] becauseArgs)
     {
-        /// <summary>Asserts the <see cref="Assembly"/> to have a specific public key.</summary>
-        public static AndConstraint<AssemblyAssertions> HavePublicKey(this AssemblyAssertions assertions, string publicKey, string because = "", params object[] becauseArgs)
-        {
-            Guard.NotNull(assertions, nameof(assertions));
+        Guard.NotNull(assertions, nameof(assertions));
 
-            var bytes = assertions.Subject.GetName().GetPublicKey() ?? Array.Empty<byte>();
-            var assemblyKey = BitConverter.ToString(bytes).Replace("-", "");
+        var bytes = assertions.Subject.GetName().GetPublicKey() ?? Array.Empty<byte>();
+        var assemblyKey = BitConverter.ToString(bytes).Replace("-", "");
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(assemblyKey == publicKey)
-                .FailWith(
-                $"Expected '{assertions.Subject}' to have public key: {publicKey},{Environment.NewLine}" +
-                $"but got: {assemblyKey} instead.");
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(assemblyKey == publicKey)
+            .FailWith(
+            $"Expected '{assertions.Subject}' to have public key: {publicKey},{Environment.NewLine}" +
+            $"but got: {assemblyKey} instead.");
 
-            return new AndConstraint<AssemblyAssertions>(assertions);
-        }
+        return new AndConstraint<AssemblyAssertions>(assertions);
     }
 }


### PR DESCRIPTION
Most storage implementing event sourcing define their versions as `long`s. This should simplify things.