### PR TITLE
Reintroduction of If() after Then on immutable collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 | version                                                                      | package                                                                                    |
 |------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-0.2.0-blue.svg?cacheSeconds=3600)   |[Qowaiv.DomainModel](https://www.nuget.org/packages/Qowaiv.DomainModel/)                    |
-|![v](https://img.shields.io/badge/version-0.1.0-darkred.svg?cacheSeconds=3600)|[Qowaiv.DomainModel.TestTools](https://www.nuget.org/packages/Qowaiv.DomainModel.TestTools/)|
+|![v](https://img.shields.io/badge/version-1.0.1-blue.svg?cacheSeconds=3600)   |[Qowaiv.DomainModel](https://www.nuget.org/packages/Qowaiv.DomainModel/)                    |
+|![v](https://img.shields.io/badge/version-1.0.0-darkred.svg?cacheSeconds=3600)|[Qowaiv.DomainModel.TestTools](https://www.nuget.org/packages/Qowaiv.DomainModel.TestTools/)|
 
 # Qowaiv Domain Model
 Qowaiv Domain Model is a library containing the (abstract) building blocks to

--- a/src/Qowaiv.DomainModel/Collections/If.cs
+++ b/src/Qowaiv.DomainModel/Collections/If.cs
@@ -5,11 +5,11 @@
 public sealed class If
 {
     /// <summary>Initializes a new instance of the <see cref="If"/> class.</summary>
-    internal If(bool condition, ImmutableCollection collection)
+    internal If(bool condition, AppendOnlyCollection collection)
         : this(condition ? IfState.True : IfState.False, collection) { }
 
     /// <summary>Initializes a new instance of the <see cref="If"/> class.</summary>
-    internal If(IfState state, ImmutableCollection collection)
+    internal If(IfState state, AppendOnlyCollection collection)
     {
         State = state;
         Collection = collection;
@@ -21,7 +21,7 @@ public sealed class If
 
     /// <summary>The parent <see cref="ImmutableCollection"/>.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    internal ImmutableCollection Collection { get; }
+    internal AppendOnlyCollection Collection { get; }
 
     /// <summary>Creates a new <see cref="ImmutableCollection"/> with the added item(s)
     /// if the condition is met.</summary>

--- a/src/Qowaiv.DomainModel/Collections/ImmutableCollection.cs
+++ b/src/Qowaiv.DomainModel/Collections/ImmutableCollection.cs
@@ -12,6 +12,7 @@ public sealed class ImmutableCollection : IReadOnlyCollection<object>
     /// <summary>Gets an empty immutable collection.</summary>
     public static readonly ImmutableCollection Empty = new(AppendOnlyCollection.Empty);
 
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal readonly AppendOnlyCollection Items;
 
     /// <summary>Initializes a new instance of the <see cref="ImmutableCollection"/> class.</summary>
@@ -44,7 +45,7 @@ public sealed class ImmutableCollection : IReadOnlyCollection<object>
 
     /// <summary>Starts a conditional addition.</summary>
     [Pure]
-    public If If(bool condition) => new(condition, this);
+    public If If(bool condition) => new(condition, Items);
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()" />
     [Pure]

--- a/src/Qowaiv.DomainModel/Collections/Then.cs
+++ b/src/Qowaiv.DomainModel/Collections/Then.cs
@@ -6,13 +6,14 @@
 public sealed class Then : IReadOnlyCollection<object>
 {
     /// <summary>Initializes a new instance of the <see cref="Then"/> class.</summary>
-    internal Then(bool done, ImmutableCollection item)
+    internal Then(bool done, AppendOnlyCollection item)
     {
         Items = item;
         Done = done;
     }
 
-    private readonly ImmutableCollection Items;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly AppendOnlyCollection Items;
 
     /// <summary>The predecessor <see cref="ImmutableCollection"/>.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -29,7 +30,7 @@ public sealed class Then : IReadOnlyCollection<object>
     /// Null, and null items are ignored.
     /// </remarks>
     [Pure]
-    public ImmutableCollection Add(object? item) => Items.Add(item!);
+    public ImmutableCollection Add(object? item) => new(Items.Add(item));
 
     /// <summary>Creates a new <see cref="ImmutableCollection"/> with the added items.</summary>
     /// <remarks>
@@ -37,6 +38,14 @@ public sealed class Then : IReadOnlyCollection<object>
     /// </remarks>
     [Pure]
     public ImmutableCollection AddRange(params object?[]? items) => Add(items);
+
+    /// <summary>Starts a conditional addition.</summary>
+    [Pure]
+    public If If(bool? condition) => If(condition == true);
+
+    /// <summary>Starts a conditional addition.</summary>
+    [Pure]
+    public If If(bool condition) => new(condition, Items);
 
     /// <summary>Adds else-if condition.</summary>
     [Pure]
@@ -59,8 +68,8 @@ public sealed class Then : IReadOnlyCollection<object>
     [Pure]
     public ImmutableCollection Else<TElseItem>(Func<TElseItem> item) where TElseItem : class
         => Done || item is null
-        ? Items
-        : Items.Add(item());
+        ? new(Items)
+        : new(Items.Add(item()));
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()" />
     [Pure]

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageReleaseNotes>
+v1.0.1
+- Reintroduce If() on Then(). #40
 v1.0.0
 - Renamed AggregateRoot to Aggregate. #35 (breaking)
 - Re-implemented ImmutableCollection. #34 (breaking)

--- a/test/Qowaiv.DomainModel.UnitTests/Collections/Immutable_Collection_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Collections/Immutable_Collection_specs.cs
@@ -200,28 +200,64 @@ public class If_true
     }
 }
 
-public class Then
+public class Then_
 {
-    [Test]
-    public void Add_is_executed_after_true_branch()
+    public class if_true
     {
-        var events = ImmutableCollection.Empty
-           .If(true)
-               .Then(() => new Dummy())
-            .Add(new Dummy());
+        private readonly Then IfTrue = ImmutableCollection
+            .Empty.If(true)
+                .Then(() => new Dummy());
 
-        events.Should().HaveCount(2);
+        [Test]
+        public void Adds_item() 
+            => IfTrue.Add(new Dummy())
+                .Should().HaveCount(2);
+
+        [Test]
+        public void Adds_range_of_items()
+            => IfTrue.AddRange(new Dummy(), new Dummy())
+                .Should().HaveCount(3);
+
+        [Test]
+        public void If_true_adds()
+            => IfTrue.If(true)
+                .Then(() => new Dummy())
+            .Should().HaveCount(2);
+
+        [Test]
+        public void If_false_does_not_add()
+            => IfTrue.If(false)
+                .Then(() => new Dummy())
+            .Should().HaveCount(1);
     }
 
-    [Test]
-    public void Add_is_executed_after_false_branch()
+    public class if_false
     {
-        var events = ImmutableCollection.Empty
-           .If(false)
-               .Then(() => new Dummy())
-            .Add(new Dummy());
+        private readonly Then IfFalse = ImmutableCollection
+          .Empty.If(false)
+              .Then(() => new Dummy());
 
-        events.Should().HaveCount(1);
+        [Test]
+        public void Adds_item()
+            => IfFalse.Add(new Dummy())
+                .Should().HaveCount(1);
+
+        [Test]
+        public void Adds_range_of_items()
+            => IfFalse.AddRange(new Dummy(), new Dummy())
+                .Should().HaveCount(2);
+
+        [Test]
+        public void If_true_adds()
+            => IfFalse.If(true)
+                .Then(() => new Dummy())
+            .Should().HaveCount(1);
+
+        [Test]
+        public void If_false_does_not_add()
+            => IfFalse.If(false)
+                .Then(() => new Dummy())
+            .Should().BeEmpty();
     }
 }
 


### PR DESCRIPTION
With the re-implementation of the immutable collection, unintentionally, the `.If()` on `Then` has been dropped.