### PR TITLE
Expose supported event types

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: .NET 7.0 Build & Test
+name: .NET 8.0 Build & Test
 
 on: [push]
 
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET 7.0
+    - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Test with .NET
       run: dotnet test --configuration Release

--- a/example/ConquerClub.Domain/ConquerClub.Domain.csproj
+++ b/example/ConquerClub.Domain/ConquerClub.Domain.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\nopackage.props" />
   
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/example/ConquerClub.UnitTests/ConquerClub.UnitTests.csproj
+++ b/example/ConquerClub.UnitTests/ConquerClub.UnitTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\nopackage.props" />
   
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/props/common.props
+++ b/props/common.props
@@ -8,7 +8,7 @@
     <PackageTags>qowaiv domain model</PackageTags>
     <Company>Qowaiv community</Company>
     <Copyright>Copyright © Qowaiv community 2013-current</Copyright>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <!-- We ship package versions for obsolete target frameworks too -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/props/common.props
+++ b/props/common.props
@@ -19,18 +19,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AsyncFixer" Version="1.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*-*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+   </ItemGroup>
+   <ItemGroup Label="Analyzers">
+    <PackageReference Include="AsyncFixer" Version="*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*-*" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- for code coverage an proper debugging -->

--- a/props/package.props
+++ b/props/package.props
@@ -26,15 +26,9 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\build\Qowaiv.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="0.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.*-*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Qowaiv.DomainModel.TestTools/Qowaiv.DomainModel.TestTools.csproj
+++ b/src/Qowaiv.DomainModel.TestTools/Qowaiv.DomainModel.TestTools.csproj
@@ -3,10 +3,12 @@
   <Import Project="..\..\props\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <PackageReleaseNotes>
+ToBeRealesed
+- Publish .NET 8.0. #41
 v1.0.0
 - Assertions helpers are FluentAssertion based. #35 (breaking)
 - Enable annotations. #31

--- a/src/Qowaiv.DomainModel/Aggregate.cs
+++ b/src/Qowaiv.DomainModel/Aggregate.cs
@@ -1,4 +1,6 @@
-﻿namespace Qowaiv.DomainModel;
+﻿using System.Reflection;
+
+namespace Qowaiv.DomainModel;
 
 /// <summary>Factory method for creating <see cref="Aggregate{TAggregate, TId}"/> from stored events.</summary>
 public static class Aggregate
@@ -23,4 +25,22 @@ public static class Aggregate
         aggregate.Replay(buffer);
         return aggregate;
     }
+
+    /// <inheritdoc cref="EventDispatcher.SupportedEventTypes" />
+    [Pure]
+    public static ReadOnlySet<Type> SupportedEventTypes<TAggregate>()
+        where TAggregate : Aggregate<TAggregate>, new()
+    {
+        return Dispatcher(new TAggregate()).SupportedEventTypes;
+
+        EventDispatcher Dispatcher(TAggregate aggregate)
+            => (EventDispatcher)typeof(TAggregate)
+                .GetProperty(nameof(Dispatcher), NonPublic)!
+                .GetValue(aggregate)!;
+    }
+
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+    // We own the code.
+    private const BindingFlags NonPublic = BindingFlags.Instance | BindingFlags.NonPublic;
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 }

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -8,8 +8,8 @@
     <Version>1.1.0</Version>
     <PackageReleaseNotes>
 v1.1.0
+- Expose supported event types via Aggregate.SupportedEventTypes(). #41
 - Publish .NET 8.0.
-- Expose supported event types via Aggregate.SupportedEventTypes().
 v1.0.1
 - Reintroduce If() on Then(). #40
 v1.0.0

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageReleaseNotes>
+v1.0.2
+- Expose supported event types via Aggregate.SupportedEventTypes().
 v1.0.1
 - Reintroduce If() on Then(). #40
 v1.0.0

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -3,11 +3,12 @@
   <Import Project="..\..\props\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <PackageReleaseNotes>
-v1.0.2
+v1.1.0
+- Publish .NET 8.0.
 - Expose supported event types via Aggregate.SupportedEventTypes().
 v1.0.1
 - Reintroduce If() on Then(). #40

--- a/test/Qowaiv.DomainModel.UnitTests/Qowaiv.DomainModel.UnitTests.csproj
+++ b/test/Qowaiv.DomainModel.UnitTests/Qowaiv.DomainModel.UnitTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\props\nopackage.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.DomainModel.UnitTests/Qowaiv.DomainModel.UnitTests.csproj
+++ b/test/Qowaiv.DomainModel.UnitTests/Qowaiv.DomainModel.UnitTests.csproj
@@ -12,19 +12,16 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.*" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
     <PackageReference Include="Qowaiv.TestTools" Version="6.4.0" />
     <PackageReference Include="Qowaiv.Validation.TestTools" Version="0.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="FluentAssertions.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.DomainModel.UnitTests/Supported_EventTypes_specs.cs
+++ b/test/Qowaiv.DomainModel.UnitTests/Supported_EventTypes_specs.cs
@@ -1,0 +1,19 @@
+﻿using Qowaiv.DomainModel;
+
+namespace Supported_EventTypes_specs;
+
+public class Exposes
+{
+    [Test]
+    public void Supported_EventTypes_of_protected_dispatcher()
+    {
+        Aggregate.SupportedEventTypes<SimpleEventSourcedAggregate>()
+            .Should().BeEquivalentTo(
+            [
+                typeof(NameUpdated),
+                typeof(DateOfBirthUpdated),
+                typeof(SimpleInitEvent),
+                typeof(InvalidEvent),
+            ]);
+    }
+}


### PR DESCRIPTION
For multiple purposes it is desired to be able to know with event types are supported (handled) by the aggregate.