### PR TITLE
The CommandProcessor should be thread-safe

### DIFF
--- a/src/Qowaiv.DomainModel/Commands/CommandProcessor.cs
+++ b/src/Qowaiv.DomainModel/Commands/CommandProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using System.Collections.Concurrent;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Qowaiv.DomainModel.Commands;
@@ -16,7 +17,7 @@ namespace Qowaiv.DomainModel.Commands;
 public abstract class CommandProcessor<TReturnType>
 {
     /// <summary>Gets the command types sent at least once by the command processor.</summary>
-    public IReadOnlyCollection<object> CommandTypes => handlers.Keys;
+    public IReadOnlyCollection<object> CommandTypes => [..handlers.Keys];
 
     /// <summary>The generic type definition of the command handlers to support.</summary>
     /// <remarks>
@@ -142,5 +143,5 @@ public abstract class CommandProcessor<TReturnType>
         return Expression.Lambda<Func<object, object, CancellationToken, TReturnType>>(body, handler, cmd, token);
     }
 
-    private readonly Dictionary<Type, Func<object, object, CancellationToken, TReturnType>> handlers = new();
+    private readonly ConcurrentDictionary<Type, Func<object, object, CancellationToken, TReturnType>> handlers = new();
 }

--- a/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
+++ b/src/Qowaiv.DomainModel/Qowaiv.DomainModel.csproj
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageReleaseNotes>
+v1.1.1
+- CommandProcessor made thread-safe. #42
 v1.1.0
 - Expose supported event types via Aggregate.SupportedEventTypes(). #41
 - Publish .NET 8.0.


### PR DESCRIPTION
By using a `ConcurrentDictionary` the thread-safety issue has been resolved.